### PR TITLE
add ingress and tls support

### DIFF
--- a/charts/brigade-prometheus/templates/grafana/cert-secret.yaml
+++ b/charts/brigade-prometheus/templates/grafana/cert-secret.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.grafana.tls.enabled (or .Values.grafana.tls.generateSelfSignedCert .Values.grafana.tls.cert) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade-prometheus.grafana.fullname" . }}-cert
+  labels:
+    {{- include "brigade-prometheus.labels" . | nindent 4 }}
+    {{- include "brigade-prometheus.grafana.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.grafana.tls.generateSelfSignedCert }}
+  {{- $altName1 := include "brigade-prometheus.grafana.fullname" . }}
+  {{- $altName2 := printf "%s.%s" (include "brigade-prometheus.grafana.fullname" .) .Release.Namespace }}
+  {{- $altName3 := printf "%s.%s.svc" (include "brigade-prometheus.grafana.fullname" .) .Release.Namespace }}
+  {{- $altName4 := printf "%s.%s.svc.cluster" (include "brigade-prometheus.grafana.fullname" .) .Release.Namespace }}
+  {{- $altName5 := printf "%s.%s.svc.cluster.local" (include "brigade-prometheus.grafana.fullname" .) .Release.Namespace }}
+  {{- $cert := genSelfSignedCert .Values.grafana.host nil (list .Values.grafana.host $altName1 $altName2 $altName3 $altName4 $altName5) 3650 }}
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+  {{- else }}
+  tls.crt: {{ .Values.grafana.tls.cert }}
+  tls.key: {{ .Values.grafana.tls.key }}
+  {{- end }}
+{{- end }}

--- a/charts/brigade-prometheus/templates/grafana/configmap.yaml
+++ b/charts/brigade-prometheus/templates/grafana/configmap.yaml
@@ -14,15 +14,25 @@ data:
 
     http {
         server {
+            {{- if .Values.grafana.tls.enabled }}
+            listen 443 ssl;
+            server_name         www.example.com;
+            ssl_certificate     /var/lib/nginx/certs/tls.crt;
+            ssl_certificate_key /var/lib/nginx/certs/tls.key;
+            {{- else }}
             listen 80;
+            {{- end }}
+        
             root /usr/share/nginx/html;
             index index.html index.htm;
 
             location / {
               proxy_pass            http://localhost:3000/;
               proxy_set_header      Authorization "";
+              {{- if .Values.grafana.auth.proxy }}
               auth_basic            "Administrator’s Area";
               auth_basic_user_file  /etc/nginx/.htpasswd; 
+              {{- end }}
             }
         }
     }

--- a/charts/brigade-prometheus/templates/grafana/deployment.yaml
+++ b/charts/brigade-prometheus/templates/grafana/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/grafana/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/grafana/secret.yaml") . | sha256sum }}
+        {{- if .Values.grafana.tls.enabled }}
+        checksum/cert-secret: {{ include (print $.Template.BasePath "/grafana/cert-secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       containers:
       - name: grafana
@@ -46,27 +49,35 @@ spec:
           mountPath: /etc/grafana/provisioning/datasources
         - name: grafana-storage
           mountPath: /var/lib/grafana/data
-        ports:
-        - containerPort: 3000
-          name: http-grafana
-          protocol: TCP
-      {{- if .Values.grafana.auth.proxy }}
       - name: nginx
         image: {{ .Values.nginx.image.repository }}:{{ default .Chart.AppVersion .Values.nginx.image.tag }}
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         volumeMounts:
         - name: nginx-config
           mountPath: /etc/nginx/
+        {{- if .Values.grafana.tls.enabled }}
+        - name: cert
+          mountPath: /var/lib/nginx/certs
+          readOnly: true
+        {{- end }}
         ports:
-        - containerPort: 80
-          name: nginx-grafana
+        {{- if .Values.grafana.tls.enabled }}
+        - containerPort: 443
+          name: https
           protocol: TCP
-      {{- end }}
+        {{- else }}
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        {{- end }}
       volumes:
-      {{- if .Values.grafana.auth.proxy }}
       - name: nginx-config
         configMap:
           name: {{ include "brigade-prometheus.nginx.fullname" . }}
+      {{- if .Values.grafana.tls.enabled }}
+      - name: cert
+        secret:
+          secretName: {{ include "brigade-prometheus.grafana.fullname" . }}-cert
       {{- end }}
       - name: grafana-datasources
         configMap:

--- a/charts/brigade-prometheus/templates/grafana/ingress-cert-secret.yaml
+++ b/charts/brigade-prometheus/templates/grafana/ingress-cert-secret.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.grafana.ingress.enabled .Values.grafana.ingress.tls.enabled (or .Values.grafana.ingress.tls.generateSelfSignedCert .Values.grafana.ingress.tls.cert) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade-prometheus.grafana.fullname" . }}-ingress-cert
+  labels:
+    {{- include "brigade-prometheus.labels" . | nindent 4 }}
+    {{- include "brigade-prometheus.grafana.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.grafana.ingress.tls.generateSelfSignedCert }}
+  {{- $cert := genSelfSignedCert .Values.grafana.host nil (list .Values.grafana.host) 3650 }}
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+  {{- else }}
+  tls.crt: {{ .Values.grafana.ingress.tls.cert }}
+  tls.key: {{ .Values.grafana.ingress.tls.key }}
+  {{- end }}
+{{- end }}

--- a/charts/brigade-prometheus/templates/grafana/ingress.yaml
+++ b/charts/brigade-prometheus/templates/grafana/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.grafana.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "brigade-prometheus.grafana.fullname" . }}
+  labels:
+    {{- include "brigade-prometheus.labels" . | nindent 4 }}
+    {{- include "brigade-prometheus.grafana.labels" . | nindent 4 }}
+  {{- with .Values.grafana.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.grafana.host }}
+    http:
+      paths:
+      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      - pathType: ImplementationSpecific
+        path: /
+        backend:
+          service:
+            name: {{ include "brigade-prometheus.grafana.fullname" . }}
+            port:
+              {{- if .Values.grafana.tls.enabled }}
+              number: 443
+              {{- else }}
+              number: 80
+              {{- end }}
+      {{- else }}
+      - backend:
+          serviceName: {{ include "brigade-prometheus.grafana.fullname" . }}
+          {{- if .Values.grafana.tls.enabled }}
+          servicePort: 443
+          {{- else }}
+          servicePort: 80
+          {{- end }}
+      {{- end}}
+  {{- if .Values.grafana.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.grafana.host }}
+    secretName: {{ include "brigade-prometheus.grafana.fullname" . }}-ingress-cert
+  {{- end }}
+{{- end }}

--- a/charts/brigade-prometheus/templates/grafana/service.yaml
+++ b/charts/brigade-prometheus/templates/grafana/service.yaml
@@ -8,12 +8,13 @@ metadata:
 spec:
   type: {{ .Values.grafana.service.type }}
   ports:
+  {{- if .Values.grafana.tls.enabled }}
+  - port: 443
+    targetPort: 443
+  {{- else }}
   - port: 80
-    {{- if .Values.grafana.auth.proxy }}
     targetPort: 80
-    {{- else }}
-    targetPort: 3000
-    {{- end }}
+  {{- end }}
     {{- if and (or (eq .Values.grafana.service.type "NodePort") (eq .Values.grafana.service.type "LoadBalancer")) .Values.grafana.service.nodePort}}
     nodePort: {{ .Values.grafana.service.nodePort }}
     {{- end }}

--- a/charts/brigade-prometheus/values.yaml
+++ b/charts/brigade-prometheus/values.yaml
@@ -82,6 +82,10 @@ prometheus:
 
 grafana:
 
+  ## Host should be set accurately for a variety of reasons including
+  ## ingress resources and cert generation.
+  host: localhost:31700
+
   image:
     repository: quillie/brigade-prometheus-grafana
     ## tag should only be specified if you want to override Chart.appVersion
@@ -89,6 +93,7 @@ grafana:
     # tag:
     pullPolicy: IfNotPresent
 
+  ## TODO: Clean up and document these options
   auth:
     ## Specify whether or not to use a reverse proxy + shared account
     proxy: true
@@ -98,6 +103,29 @@ grafana:
   volumes:
     storageClass: standard
     accessMode: ReadWriteOnce
+
+  tls:
+    ## Whether to enable TLS. If true then you MUST do ONE of three things to
+    ## ensure the existence of a TLS certificate:
+    ##
+    ## 1. Set generateSelfSignedCert below to true (the default)
+    ## 2. OR Set values for BOTH the cert and key fields below
+    ## 3. OR create a cert secret named <Helm release name>-grafana-cert in
+    ##    the same namespace as Brigade Prometheus. This secret could be created
+    ##    manually or through other means, such as a cert manager.
+    enabled: true
+    ## Whether to generate a self-signed certificate. If true, a new certificate
+    ## will be generated for every revision of the corresponding Helm release.
+    ## Since the certificate is self-signed, it will not be trusted by clients
+    ## and should absolutely not be used for production, but having this enabled
+    ## as a default effectively discourages the more heavy-handed option to
+    ## disable TLS entirely. If TLS is enabled and cert generation is DISABLED,
+    ## users MUST provide their own cert and private key below OR create a cert
+    ## secret named <Helm release name>-grafana-cert in the same namespace as
+    ## Brigade Prometheus.
+    generateSelfSignedCert: true
+    # cert: base 64 encoded cert goes here
+    # key: base 64 encoded key goes here
 
   ingress:
     ## Whether to enable ingress. By default, this is disabled. Enabling ingress


### PR DESCRIPTION
We had half-baked "support" for HTTPS / TLS prior to this. Options existed in `values.yaml`, but we weren't doing anything with them.

The options introduced here are modeled directly after Brigade 2 itself and are pretty well battle-tested at this point.

You can:

1. Optionally enable TLS on Grafana
    1. Autogenerate a self-signed certificate
    1. Or bring your own certificate (could be created manually or come from a cert manager)
1. Optionally enable ingress for Grafana
    1. With or without TLS
        1. Autogenerate a self-signed certificate
        1. Or bring your own certificate (could be created manually or come from a cert manager)
    1. Both TLS and non-TLS backends are supported
 
Note that with this change, we _always_ use the Nginx reverse proxy/sidecar because:

1. See above-- there are already enough permutations. We don't need more.
1. Nginx is a reliable way to provide TLS, so if we were going to use it sometimes to enforce basic auth, we may as well always use it.

Whether the Nginx reverse proxy/sidecar enforces basic auth or not remains conditional.