### PR TITLE
add security contexts for prometheus and grafana deployments

### DIFF
--- a/charts/brigade-prometheus/templates/grafana/deployment.yaml
+++ b/charts/brigade-prometheus/templates/grafana/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       - name: grafana
         image: {{ .Values.grafana.image.repository }}:{{ default .Chart.AppVersion .Values.grafana.image.tag }}
         imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+        securityContext:
+          runAsGroup: 472
+          runAsNonRoot: true
+          runAsUser: 472
         env:
         {{- if .Values.grafana.auth.proxy }}
         - name: GF_AUTH_ANONYMOUS_ENABLED
@@ -84,7 +88,9 @@ spec:
           name: {{ include "brigade-prometheus.grafana.fullname" . }}-datasources
       - name: grafana-storage
         persistentVolumeClaim:
-          claimName: pvc-{{ include "brigade-prometheus.grafana.fullname" . }}
+          claimName: {{ include "brigade-prometheus.grafana.fullname" . }}
+      securityContext:
+        fsGroup: 472
       {{- with .Values.grafana.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/brigade-prometheus/templates/grafana/persistentVolumeClaim.yaml
+++ b/charts/brigade-prometheus/templates/grafana/persistentVolumeClaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata: 
-  name: pvc-{{ include "brigade-prometheus.grafana.fullname" . }}
+  name: {{ include "brigade-prometheus.grafana.fullname" . }}
   labels:
     {{- include "brigade-prometheus.labels" . | nindent 4 }}
     {{- include "brigade-prometheus.grafana.labels" . | nindent 4 }}

--- a/charts/brigade-prometheus/templates/prometheus/deployment.yaml
+++ b/charts/brigade-prometheus/templates/prometheus/deployment.yaml
@@ -39,7 +39,12 @@ spec:
           name: {{ include "brigade-prometheus.prometheus.fullname" . }}
       - name: prometheus-storage-volume
         persistentVolumeClaim:
-          claimName: pvc-{{ include "brigade-prometheus.prometheus.fullname" . }}
+          claimName: {{ include "brigade-prometheus.prometheus.fullname" . }}
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
       {{- with .Values.prometheus.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/brigade-prometheus/templates/prometheus/persistentVolumeClaim.yaml
+++ b/charts/brigade-prometheus/templates/prometheus/persistentVolumeClaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata: 
-  name: pvc-{{ include "brigade-prometheus.prometheus.fullname" . }}
+  name: {{ include "brigade-prometheus.prometheus.fullname" . }}
   labels:
     {{- include "brigade-prometheus.labels" . | nindent 4 }}
     {{- include "brigade-prometheus.prometheus.labels" . | nindent 4 }}


### PR DESCRIPTION
In a previous state, the chart was using init containers to set fs ownership/permissions on Prometheus and Grafana's volumes. That was removed because things were working out (in KinD) without those init containers...

In an AKS cluster, however, it's a different story (not clear on why), and those adjustments _do_ need to be made.

Pod and container security contexts are the more conventional way to approach this, however.

What this PR does is:

* Adds a pod security context for prometheus
* For Grafana, adds a pod security context that allows all processes in all containers in the pod to access Grafana's data volume. This _has_ to be done at the pod level. For the rest of the security context, the changes are applies at the container level since the Grafana container needs those settings, but the Nginx sidecar _fails_ if you mess with its security context.

Also, I simplified the names of PVCs. They were previously prefixed with `pvc-` and besides being unnecessary, it's inconsistent since none of the other k8s resources are prefixed with their type.

fwiw, I anticipate that this is the first of several PRs related to the topic of security context, and persistence in general. I do believe that not all volume types support security contexts and that we _might_ have to expose an _option_ for permissions to be straightened out using an init container instead.

I'll also have some follow-up PRs to make volume size configurable and to also expose persistence-related options in a more conventional way (there's a _de facto_ pattern for this that's been broadly applied across most charts from most sources).