### PR TITLE
bit of exporter cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,14 @@ IMMUTABLE_DOCKER_TAG := $(VERSION)
 .PHONY: lint
 lint:
 	$(GO_DOCKER_CMD) sh -c ' \
-		cd /exporter && \
-		golangci-lint run --config ../../golangci.yaml \
+		cd exporter && \
+		golangci-lint run --config ../golangci.yaml \
 	'
 
 .PHONY: test-unit
 test-unit:
 	$(GO_DOCKER_CMD) sh -c ' \
-		cd /exporter && \
+		cd exporter && \
 		go test \
 			-v \
 			-timeout=60s \

--- a/charts/brigade-metrics/templates/exporter/deployment.yaml
+++ b/charts/brigade-metrics/templates/exporter/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               name: {{ include "brigade-metrics.exporter.fullname" . }}
               key: api-token
         - name: API_IGNORE_CERT_WARNINGS
-          value: {{ quote .Values.exporter.brigade.ignoreCertWarnings }}
+          value: {{ quote .Values.exporter.brigade.apiIgnoreCertWarnings }}
         - name: PROM_SCRAPE_INTERVAL
           value: {{ quote .Values.prometheus.scrapeInterval }}
       {{- with .Values.exporter.nodeSelector }}

--- a/charts/brigade-metrics/templates/prometheus/configmap.yaml
+++ b/charts/brigade-metrics/templates/prometheus/configmap.yaml
@@ -17,7 +17,7 @@ data:
     - job_name: 'node-exporter'
 
       # Override the global default and scrape targets from this job every 5 seconds.
-      scrape_interval: {{ .Values.prometheus.scrapeInterval }}s
+      scrape_interval: {{ .Values.prometheus.scrapeInterval }}
 
       static_configs:
       - targets:

--- a/charts/brigade-metrics/values.yaml
+++ b/charts/brigade-metrics/values.yaml
@@ -53,7 +53,7 @@ prometheus:
     tag: v2.28.0
     pullPolicy: IfNotPresent
 
-  scrapeInterval: 3
+  scrapeInterval: 3s
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as

--- a/exporter/config.go
+++ b/exporter/config.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/http"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/os"
+)
+
+// apiClientConfig populates the Brigade SDK's APIClientOptions from
+// environment variables.
+func apiClientConfig() (string, string, restmachinery.APIClientOptions, error) {
+	opts := restmachinery.APIClientOptions{}
+	address, err := os.GetRequiredEnvVar("API_ADDRESS")
+	if err != nil {
+		return address, "", opts, err
+	}
+	token, err := os.GetRequiredEnvVar("API_TOKEN")
+	if err != nil {
+		return address, token, opts, err
+	}
+	opts.AllowInsecureConnections, err =
+		os.GetBoolFromEnvVar("API_IGNORE_CERT_WARNINGS", false)
+	return address, token, opts, err
+}
+
+func scrapeDuration() (time.Duration, error) {
+	return os.GetDurationFromEnvVar("PROM_SCRAPE_INTERVAL", 5*time.Second)
+}
+
+// serverConfig populates configuration for the HTTP/S server from environment
+// variables.
+func serverConfig() (http.ServerConfig, error) {
+	config := http.ServerConfig{}
+	var err error
+	config.Port, err = os.GetIntFromEnvVar("RECEIVER_PORT", 8080)
+	if err != nil {
+		return config, err
+	}
+	config.TLSEnabled, err = os.GetBoolFromEnvVar("TLS_ENABLED", false)
+	if err != nil {
+		return config, err
+	}
+	if config.TLSEnabled {
+		config.TLSCertPath, err = os.GetRequiredEnvVar("TLS_CERT_PATH")
+		if err != nil {
+			return config, err
+		}
+		config.TLSKeyPath, err = os.GetRequiredEnvVar("TLS_KEY_PATH")
+		if err != nil {
+			return config, err
+		}
+	}
+	return config, nil
+}

--- a/exporter/config_test.go
+++ b/exporter/config_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	clientRM "github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/stretchr/testify/require"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/http"
+)
+
+// Note that unit testing in Go does NOT clear environment variables between
+// tests, which can sometimes be a pain, but it's fine here-- so each of these
+// test functions uses a series of test cases that cumulatively build upon one
+// another.
+
+func TestAPIClientConfig(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(
+			address string,
+			token string,
+			opts clientRM.APIClientOptions,
+			err error,
+		)
+	}{
+		{
+			name:  "API_ADDRESS not set",
+			setup: func() {},
+			assertions: func(
+				_ string,
+				_ string,
+				_ clientRM.APIClientOptions,
+				err error,
+			) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "API_ADDRESS")
+			},
+		},
+		{
+			name: "API_TOKEN not set",
+			setup: func() {
+				os.Setenv("API_ADDRESS", "foo")
+			},
+			assertions: func(
+				_ string,
+				_ string,
+				_ restmachinery.APIClientOptions,
+				err error,
+			) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "API_TOKEN")
+			},
+		},
+		{
+			name: "SUCCESS not set",
+			setup: func() {
+				os.Setenv("API_TOKEN", "bar")
+				os.Setenv("API_IGNORE_CERT_WARNINGS", "true")
+			},
+			assertions: func(
+				address string,
+				token string,
+				opts restmachinery.APIClientOptions,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, "foo", address)
+				require.Equal(t, "bar", token)
+				require.True(t, opts.AllowInsecureConnections)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			address, token, opts, err := apiClientConfig()
+			testCase.assertions(address, token, opts, err)
+		})
+	}
+}
+
+func TestServerConfig(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(http.ServerConfig, error)
+	}{
+		{
+			name: "RECEIVER_PORT not an int",
+			setup: func() {
+				os.Setenv("RECEIVER_PORT", "foo")
+			},
+			assertions: func(_ http.ServerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as an int")
+				require.Contains(t, err.Error(), "RECEIVER_PORT")
+			},
+		},
+		{
+			name: "TLS_ENABLED not a bool",
+			setup: func() {
+				os.Setenv("RECEIVER_PORT", "8080")
+				os.Setenv("TLS_ENABLED", "nope")
+			},
+			assertions: func(_ http.ServerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as a bool")
+				require.Contains(t, err.Error(), "TLS_ENABLED")
+			},
+		},
+		{
+			name: "TLS_CERT_PATH required but not set",
+			setup: func() {
+				os.Setenv("TLS_ENABLED", "true")
+			},
+			assertions: func(_ http.ServerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "TLS_CERT_PATH")
+			},
+		},
+		{
+			name: "TLS_KEY_PATH required but not set",
+			setup: func() {
+				os.Setenv("TLS_CERT_PATH", "/var/ssl/cert")
+			},
+			assertions: func(_ http.ServerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "TLS_KEY_PATH")
+			},
+		},
+		{
+			name: "success",
+			setup: func() {
+				os.Setenv("TLS_KEY_PATH", "/var/ssl/key")
+			},
+			assertions: func(config http.ServerConfig, err error) {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					http.ServerConfig{
+						Port:        8080,
+						TLSEnabled:  true,
+						TLSCertPath: "/var/ssl/cert",
+						TLSKeyPath:  "/var/ssl/key",
+					},
+					config,
+				)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			config, err := serverConfig()
+			testCase.assertions(config, err)
+		})
+	}
+}

--- a/exporter/internal/http/server.go
+++ b/exporter/internal/http/server.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/file"
+)
+
+// ServerConfig represents optional configuration for an HTTP/S server.
+type ServerConfig struct {
+	// Port specifies the port the server should bind to / listen on.
+	Port int
+	// TLSEnabled specifies whether the server should serve HTTP (false) or HTTPS
+	// (true).
+	TLSEnabled bool
+	// TLSCertPath is the path to a PEM-encoded x509 certificate that can be used
+	// for serving HTTPS.
+	TLSCertPath string
+	// TLSKeyPath is the path to a PEM-encoded x509 private key that can be used
+	// for serving HTTPS.
+	TLSKeyPath string
+}
+
+// Server is an interface for an HTTP/S server. This is an improvement over the
+// HTTP/S server built into Go's http package, as it exposes simple
+// configuration options and a context-sensitive ListenAndServe function.
+type Server interface {
+	// ListenAndServe runs the HTTP/S server until the provided context is
+	// canceled. This function always returns a non-nil error.
+	ListenAndServe(ctx context.Context) error
+}
+
+// server
+type server struct {
+	config  ServerConfig
+	handler http.Handler
+}
+
+// NewServer returns a new HTTP/S server.
+func NewServer(handler http.Handler, config *ServerConfig) Server {
+	if config == nil {
+		config = &ServerConfig{}
+	}
+	if config.Port == 0 {
+		config.Port = 8080
+	}
+	return &server{
+		config:  *config,
+		handler: handler,
+	}
+}
+
+func (s *server) ListenAndServe(ctx context.Context) error {
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.config.Port),
+		Handler: s.handler,
+	}
+
+	errCh := make(chan error)
+
+	if s.config.TLSEnabled {
+		if s.config.TLSCertPath == "" {
+			return errors.New(
+				"TLS was enabled, but no certificate path was specified",
+			)
+		}
+
+		if s.config.TLSKeyPath == "" {
+			return errors.New(
+				"TLS was enabled, but no key path was specified",
+			)
+		}
+
+		ok, err := file.Exists(s.config.TLSCertPath)
+		if err != nil {
+			return errors.Wrap(err, "error checking for existence of TLS cert")
+		}
+		if !ok {
+			return errors.Errorf(
+				"no TLS certificate found at path %s",
+				s.config.TLSCertPath,
+			)
+		}
+
+		if ok, err = file.Exists(s.config.TLSKeyPath); err != nil {
+			return errors.Wrap(err, "error checking for existence of TLS key")
+		}
+		if !ok {
+			return errors.Errorf("no TLS key found at path %s", s.config.TLSKeyPath)
+		}
+
+		log.Printf(
+			"Server is listening with TLS enabled on 0.0.0.0:%d",
+			s.config.Port,
+		)
+
+		go func() {
+			err := srv.ListenAndServeTLS(s.config.TLSCertPath, s.config.TLSKeyPath)
+			select {
+			case errCh <- err:
+			case <-ctx.Done():
+			}
+		}()
+	} else {
+		log.Printf(
+			"Server is listening without TLS on 0.0.0.0:%d",
+			s.config.Port,
+		)
+
+		go func() {
+			err := srv.ListenAndServe()
+			select {
+			case errCh <- err:
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// Five second grace period on shutdown
+		shutdownCtx, cancel :=
+			context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx) // nolint: errcheck
+		return ctx.Err()
+	}
+}

--- a/exporter/internal/http/server_test.go
+++ b/exporter/internal/http/server_test.go
@@ -1,0 +1,263 @@
+package http
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	const defaultPort = 8080
+	const overriddenPort = 1234
+	testCases := []struct {
+		name       string
+		config     *ServerConfig
+		assertions func(s *server)
+	}{
+		{
+			name: "without optional config",
+			assertions: func(s *server) {
+				require.NotNil(t, s.config)
+				require.Equal(t, defaultPort, s.config.Port)
+			},
+		},
+		{
+			name:   "with port not specified",
+			config: &ServerConfig{},
+			assertions: func(s *server) {
+				require.NotNil(t, s.config)
+				require.Equal(t, defaultPort, s.config.Port)
+			},
+		},
+		{
+			name: "with port specified",
+			config: &ServerConfig{
+				Port: overriddenPort,
+			},
+			assertions: func(s *server) {
+				require.NotNil(t, s.config)
+				require.Equal(t, overriddenPort, s.config.Port)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			s := NewServer(&mockHandler{}, testCase.config)
+			require.NotNil(t, s.(*server).handler)
+			testCase.assertions(s.(*server))
+		})
+	}
+}
+
+func TestListenAndServe(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func() *ServerConfig
+		assertions func(ctx context.Context, err error)
+	}{
+		{
+			name: "TLS enabled; missing cert path",
+			setup: func() *ServerConfig {
+				return &ServerConfig{
+					TLSEnabled: true,
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(
+					t,
+					"TLS was enabled, but no certificate path was specified",
+					err.Error(),
+				)
+			},
+		},
+		{
+			name: "TLS enabled; missing key path",
+			setup: func() *ServerConfig {
+				return &ServerConfig{
+					TLSEnabled:  true,
+					TLSCertPath: "/app/certs/tls.crt",
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(
+					t,
+					"TLS was enabled, but no key path was specified",
+					err.Error(),
+				)
+			},
+		},
+		{
+			name: "TLS enabled; cert not found",
+			setup: func() *ServerConfig {
+				return &ServerConfig{
+					TLSEnabled:  true,
+					TLSCertPath: "/app/certs/tls.crt",
+					TLSKeyPath:  "/app/certs/tls.key",
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(
+					t,
+					err.Error(),
+					"no TLS certificate found at path",
+				)
+			},
+		},
+		{
+			name: "TLS enabled; key not found",
+			setup: func() *ServerConfig {
+				certFile, err := ioutil.TempFile("", "tls-*.crt")
+				require.NoError(t, err)
+				return &ServerConfig{
+					TLSEnabled:  true,
+					TLSCertPath: certFile.Name(),
+					TLSKeyPath:  "/app/certs/tls.key",
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(
+					t,
+					err.Error(),
+					"no TLS key found at path",
+				)
+			},
+		},
+		{
+			name: "TLS enabled; invalid cert",
+			setup: func() *ServerConfig {
+				certFile, err := ioutil.TempFile("", "tls-*.crt")
+				require.NoError(t, err)
+				keyFile, err := ioutil.TempFile("", "tls-*.key")
+				require.NoError(t, err)
+				return &ServerConfig{
+					TLSEnabled:  true,
+					TLSCertPath: certFile.Name(),
+					TLSKeyPath:  keyFile.Name(),
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(
+					t,
+					err.Error(),
+					"failed to find any PEM data in certificate input",
+				)
+			},
+		},
+		{
+			name: "TLS enabled",
+			setup: func() *ServerConfig {
+				cert, key := generateCert(t)
+
+				certFile, err := ioutil.TempFile("", "tls-*.crt")
+				require.NoError(t, err)
+				defer certFile.Close()
+				_, err = certFile.Write(cert)
+				require.NoError(t, err)
+
+				keyFile, err := ioutil.TempFile("", "tls-*.key")
+				require.NoError(t, err)
+				defer keyFile.Close()
+				_, err = keyFile.Write(key)
+				require.NoError(t, err)
+
+				return &ServerConfig{
+					TLSEnabled:  true,
+					TLSCertPath: certFile.Name(),
+					TLSKeyPath:  keyFile.Name(),
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(t, ctx.Err(), err)
+			},
+		},
+		// TODO: re-enable if/when we can fix its tendency for intermittent failure
+		// https://github.com/brigadecore/brigade/issues/1137
+		//
+		// {
+		// 	name: "TLS not enabled",
+		// 	setup: func() *ServerConfig {
+		// 		return nil
+		// 	},
+		// 	assertions: func(ctx context.Context, err error) {
+		// 		require.Error(t, err)
+		// 		require.Equal(t, ctx.Err(), err)
+		// 	},
+		// },
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			s := NewServer(nil, testCase.setup())
+			err := s.ListenAndServe(ctx)
+			testCase.assertions(ctx, err)
+		})
+	}
+}
+
+// generateCert generates and returns a PEM encoded, self-signed x.509v3 cert
+// and corresponding PEM encoded private key. This cert and corresponding key
+// are adequate for test purposes.
+func generateCert(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+
+	serialNumberUpperBound := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberUpperBound)
+	require.NoError(t, err)
+
+	certTemplate := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore: time.Now().UTC(),
+		NotAfter:  time.Now().UTC().Add(time.Hour * 24),
+	}
+
+	certBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		certTemplate,
+		certTemplate,
+		&key.PublicKey,
+		key,
+	)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: certBytes,
+			},
+		), pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: x509.MarshalPKCS1PrivateKey(key),
+			},
+		)
+}
+
+type mockHandler struct{}
+
+func (m *mockHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
+	// No-op
+}

--- a/exporter/internal/system/healthz.go
+++ b/exporter/internal/system/healthz.go
@@ -1,0 +1,16 @@
+package system
+
+import (
+	"log"
+	"net/http"
+)
+
+// Healthz responds to an HTTP/S request with a 200 and content body "OK".
+func Healthz(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte("ok")); err != nil {
+		log.Println(err)
+	}
+}

--- a/exporter/main.go
+++ b/exporter/main.go
@@ -1,203 +1,58 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"time"
 
 	"github.com/brigadecore/brigade/sdk/v2"
-	"github.com/brigadecore/brigade/sdk/v2/authn"
-	"github.com/brigadecore/brigade/sdk/v2/core"
-	"github.com/brigadecore/brigade/sdk/v2/meta"
-	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/willie-yao/brigade-metrics/exporter/internal/os"
+	libHTTP "github.com/willie-yao/brigade-metrics/exporter/internal/http"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/signals"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/system"
+	"github.com/willie-yao/brigade-metrics/exporter/internal/version"
 )
-
-var (
-	totalRunningJobs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "brigade_running_jobs_total",
-		Help: "The total number of running jobs",
-	})
-
-	totalPendingJobs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "brigade_pending_jobs_total",
-		Help: "The total number of pending jobs",
-	})
-
-	allWorkersByPhase = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "brigade_all_workers_by_phase",
-		Help: "All workers separated by phase",
-	}, []string{"workerPhase"})
-
-	allRunningWorkersDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "brigade_all_running_workers_duration",
-		Help: "The duration of all running workers",
-	}, []string{"worker"})
-
-	totalUsers = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "brigade_users_total",
-		Help: "The total number of users",
-	})
-
-	totalServiceAccounts = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "brigade_service_accounts_total",
-		Help: "The total number of service accounts",
-	})
-
-	totalProjects = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "brigade_projects_total",
-		Help: "The total number of brigade projects",
-	})
-)
-
-func recordMetrics(client sdk.APIClient, scrapeInterval int) {
-	go func() {
-		for {
-			// brigade_running_jobs_total
-			tempRunningJobs, err :=
-				client.Core().Substrate().CountRunningJobs(context.Background())
-			if err != nil {
-				log.Println(err)
-			}
-			totalRunningJobs.Set(float64(tempRunningJobs.Count))
-
-			for _, phase := range core.WorkerPhasesAll() {
-				// brigade_all_workers_by_phase
-				eventsList, err := client.Core().Events().List(
-					context.Background(),
-					&core.EventsSelector{
-						WorkerPhases: []core.WorkerPhase{phase},
-					},
-					&meta.ListOptions{},
-				)
-				if err != nil {
-					log.Fatal(err)
-				}
-
-				allWorkersByPhase.With(
-					prometheus.Labels{"workerPhase": string(phase)},
-				).Set(float64(len(eventsList.Items) +
-					int(eventsList.RemainingItemCount)))
-
-				// brigade_all_running_workers_duration
-
-				var jobsList []core.Job
-				for _, worker := range eventsList.Items {
-					if phase == core.WorkerPhaseRunning {
-						allRunningWorkersDuration.With(
-							prometheus.Labels{"worker": worker.ID},
-						).Set(time.Since(*worker.Worker.Status.Started).Seconds())
-						// brigade_pending_jobs_total
-						for _, job := range worker.Worker.Jobs {
-							if job.Status.Phase == core.JobPhasePending {
-								jobsList = append(jobsList, job)
-							}
-						}
-					} else {
-						allRunningWorkersDuration.Delete(
-							prometheus.Labels{"worker": worker.ID},
-						)
-					}
-				}
-
-				// brigade_pending_jobs_total
-				totalPendingJobs.Set(float64(len(jobsList)))
-			}
-
-			// brigade_users_total
-			userList, err := client.Authn().Users().List(
-				context.Background(),
-				&authn.UsersSelector{},
-				&meta.ListOptions{},
-			)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			totalUsers.Set(float64(len(userList.Items) +
-				int(userList.RemainingItemCount)))
-
-			// brigade_service_accounts_total
-			saList, err := client.Authn().ServiceAccounts().List(
-				context.Background(),
-				&authn.ServiceAccountsSelector{},
-				&meta.ListOptions{},
-			)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			totalServiceAccounts.Set(float64(len(saList.Items) +
-				int(saList.RemainingItemCount)))
-
-			// brigade_projects_total
-			projectList, err := client.Core().Projects().List(
-				context.Background(),
-				&core.ProjectsSelector{},
-				&meta.ListOptions{},
-			)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			totalProjects.Set(float64(len(projectList.Items) +
-				int(projectList.RemainingItemCount)))
-
-			time.Sleep(time.Duration(scrapeInterval) * time.Second)
-		}
-	}()
-}
-
-func initializeClient() (sdk.APIClient, error) {
-	// The address of the Brigade 2 API server
-	// beginning with http:// or https//
-	apiAddress, err := os.GetRequiredEnvVar("API_ADDRESS")
-	if err != nil {
-		return nil, err
-	}
-
-	// An API token obtained using the Brigade 2 CLI
-	apiToken, err := os.GetRequiredEnvVar("API_TOKEN")
-	if err != nil {
-		return nil, err
-	}
-
-	// Boolean indicating whether or not to ignore SSL errors
-	apiIgnoreCertWarnings, err :=
-		os.GetBoolFromEnvVar("API_IGNORE_CERT_WARNINGS", true)
-	if err != nil {
-		return nil, err
-	}
-
-	// Instantiate the API Client
-	client := sdk.NewAPIClient(
-		apiAddress,
-		apiToken,
-		&restmachinery.APIClientOptions{
-			AllowInsecureConnections: apiIgnoreCertWarnings,
-		},
-	)
-
-	return client, nil
-}
 
 func main() {
-	scrapeInterval, err := os.GetIntFromEnvVar("PROM_SCRAPE_INTERVAL", 5)
-	if err != nil {
-		log.Fatal(err)
+	log.Printf(
+		"Starting Brigade Metrics Exporter -- version %s -- commit %s",
+		version.Version(),
+		version.Commit(),
+	)
+
+	ctx := signals.Context()
+
+	{
+		address, token, opts, err := apiClientConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		scrapeInterval, err := scrapeDuration()
+		if err != nil {
+			log.Fatal(err)
+		}
+		go recordMetricsLoop(
+			ctx,
+			sdk.NewAPIClient(address, token, &opts),
+			time.Duration(scrapeInterval),
+		)
 	}
 
-	client, err := initializeClient()
-	if err != nil {
-		log.Fatal(err)
+	var server libHTTP.Server
+	{
+		router := mux.NewRouter()
+		router.StrictSlash(true)
+		router.Handle("/events", promhttp.Handler()).Methods(http.MethodPost)
+		router.HandleFunc("/healthz", system.Healthz).Methods(http.MethodGet)
+		serverConfig, err := serverConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		server = libHTTP.NewServer(router, &serverConfig)
 	}
 
-	recordMetrics(client, scrapeInterval)
-
-	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":8080", nil)
+	log.Println(
+		server.ListenAndServe(signals.Context()),
+	)
 }

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2"
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	totalRunningJobs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "brigade_running_jobs_total",
+		Help: "The total number of running jobs",
+	})
+
+	totalPendingJobs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "brigade_pending_jobs_total",
+		Help: "The total number of pending jobs",
+	})
+
+	allWorkersByPhase = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "brigade_all_workers_by_phase",
+		Help: "All workers separated by phase",
+	}, []string{"workerPhase"})
+
+	allRunningWorkersDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "brigade_all_running_workers_duration",
+		Help: "The duration of all running workers",
+	}, []string{"worker"})
+
+	totalUsers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "brigade_users_total",
+		Help: "The total number of users",
+	})
+
+	totalServiceAccounts = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "brigade_service_accounts_total",
+		Help: "The total number of service accounts",
+	})
+
+	totalProjects = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "brigade_projects_total",
+		Help: "The total number of brigade projects",
+	})
+)
+
+func recordMetricsLoop(
+	ctx context.Context,
+	client sdk.APIClient,
+	scrapeInterval time.Duration,
+) {
+	ticker := time.NewTicker(scrapeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			recordMetrics(client)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func recordMetrics(client sdk.APIClient) {
+	// brigade_running_jobs_total
+	tempRunningJobs, err :=
+		client.Core().Substrate().CountRunningJobs(context.Background())
+	if err != nil {
+		log.Println(err)
+	}
+	totalRunningJobs.Set(float64(tempRunningJobs.Count))
+
+	for _, phase := range core.WorkerPhasesAll() {
+		// brigade_all_workers_by_phase
+		var eventList core.EventList
+		eventList, err = client.Core().Events().List(
+			context.Background(),
+			&core.EventsSelector{
+				WorkerPhases: []core.WorkerPhase{phase},
+			},
+			&meta.ListOptions{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		allWorkersByPhase.With(
+			prometheus.Labels{"workerPhase": string(phase)},
+		).Set(float64(len(eventList.Items) +
+			int(eventList.RemainingItemCount)))
+
+		// brigade_all_running_workers_duration
+
+		var jobsList []core.Job
+		for _, worker := range eventList.Items {
+			if phase == core.WorkerPhaseRunning {
+				allRunningWorkersDuration.With(
+					prometheus.Labels{"worker": worker.ID},
+				).Set(time.Since(*worker.Worker.Status.Started).Seconds())
+				// brigade_pending_jobs_total
+				for _, job := range worker.Worker.Jobs {
+					if job.Status.Phase == core.JobPhasePending {
+						jobsList = append(jobsList, job)
+					}
+				}
+			} else {
+				allRunningWorkersDuration.Delete(
+					prometheus.Labels{"worker": worker.ID},
+				)
+			}
+		}
+
+		// brigade_pending_jobs_total
+		totalPendingJobs.Set(float64(len(jobsList)))
+	}
+
+	// brigade_users_total
+	userList, err := client.Authn().Users().List(
+		context.Background(),
+		&authn.UsersSelector{},
+		&meta.ListOptions{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	totalUsers.Set(float64(len(userList.Items) +
+		int(userList.RemainingItemCount)))
+
+	// brigade_service_accounts_total
+	saList, err := client.Authn().ServiceAccounts().List(
+		context.Background(),
+		&authn.ServiceAccountsSelector{},
+		&meta.ListOptions{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	totalServiceAccounts.Set(float64(len(saList.Items) +
+		int(saList.RemainingItemCount)))
+
+	// brigade_projects_total
+	projectList, err := client.Core().Projects().List(
+		context.Background(),
+		&core.ProjectsSelector{},
+		&meta.ListOptions{},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	totalProjects.Set(float64(len(projectList.Items) +
+		int(projectList.RemainingItemCount)))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/brigadecore/brigade/sdk/v2 v2.0.0-alpha.5
+	github.com/gorilla/mux v1.8.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=


### PR DESCRIPTION
This PR refactors some of the exporter to be a little bit more bullet-proof. This may be the first of a few such PRs.

Highlights:

- Break the job of getting config from env vars into separate functions. This makes them more testable. (A `main()` function is hard to test.)

- Break the scraping function into _two_ functions-- one that does a single scrape and one that controls the loop. Again-- for ease of testing. Testing a single scrape is easier than testing an uninterruptible infinite loop. Speaking of which...

- Made the HTTP server and the scrape loop uninterruptible.

- HTTP server now supports TLS

- Added a health check endpoint to the server (this is a common thing; it allows Kubernetes to check on the server)