### PR TITLE
dashboard cleanup

### DIFF
--- a/grafana/dashboards/brigade.json
+++ b/grafana/dashboards/brigade.json
@@ -1,4 +1,17 @@
 {
+  "schemaVersion": 30,
+  "id": 1,
+  "uid": "xDvsAAR7k",
+  "title": "Brigade",
+  "version": 4,
+  "refresh": "5s",
+  "style": "dark",
+  "editable": false,
+  "graphTooltip": 0,
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
   "annotations": {
     "list": [
       {
@@ -12,14 +25,17 @@
       }
     ]
   },
-  "editable": false,
-  "gnetId": null,
-  "graphTooltip": 0,
-  "id": 1,
-  "links": [],
   "panels": [
     {
-      "datasource": null,
+      "id": 32,
+      "title": "Projects",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 6
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -30,27 +46,13 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
+                "color": "light-blue"
               }
             ]
           }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 8,
-        "x": 0,
-        "y": 0
-      },
-      "id": 20,
-      "interval": "5s",
-      "maxDataPoints": null,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -60,7 +62,6 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
           "values": false
         },
         "text": {},
@@ -70,18 +71,21 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "brigade_all_running_workers_duration",
-          "interval": "",
-          "legendFormat": "{{ worker }}",
+          "expr": "brigade_projects_total",
           "refId": "A"
         }
-      ],
-      "timeFrom": "5s",
-      "title": "All Running Workers Duration",
-      "type": "stat"
+      ]
     },
     {
-      "datasource": null,
+      "id": 14,
+      "title": "Events Counts by Worker Phase",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 18,
+        "h": 6
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -93,21 +97,13 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue",
-                "value": null
+                "color": "light-blue"
               }
             ]
           }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 10,
-        "x": 8,
-        "y": 0
-      },
-      "id": 14,
       "interval": "5s",
       "options": {
         "colorMode": "value",
@@ -118,7 +114,6 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
           "values": false
         },
         "text": {},
@@ -129,106 +124,38 @@
         {
           "exemplar": true,
           "expr": "brigade_all_workers_by_phase",
-          "interval": "",
           "legendFormat": "{{ workerPhase }}",
           "refId": "A"
         }
-      ],
-      "timeFrom": null,
-      "title": "Events by Worker Phase",
-      "type": "stat"
+      ]
     },
     {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 21,
-        "y": 0
-      },
-      "id": 32,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.2",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_projects_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Brigade Projects",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 21,
-        "y": 7
-      },
       "id": 22,
+      "title": "Users",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 6,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-blue"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -238,7 +165,6 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
           "values": false
         },
         "text": {},
@@ -249,23 +175,26 @@
         {
           "exemplar": true,
           "expr": "brigade_users_total",
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
-      ],
-      "title": "Total Users",
-      "type": "stat"
+      ]
     },
     {
-      "datasource": null,
+      "id": 8,
+      "title": "Pending Workloads",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 6,
+        "y": 6,
+        "w": 18,
+        "h": 12
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -297,27 +226,13 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
+                "color": "light-blue"
               }
             ]
           }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 11,
-        "w": 18,
-        "x": 0,
-        "y": 10
-      },
-      "id": 33,
-      "interval": null,
-      "maxDataPoints": null,
       "options": {
         "legend": {
           "calcs": [],
@@ -328,22 +243,31 @@
           "mode": "single"
         }
       },
-      "pluginVersion": "8.0.2",
       "targets": [
         {
           "exemplar": true,
-          "expr": "brigade_all_running_workers_duration",
-          "interval": "",
-          "legendFormat": "{{ worker }}",
+          "expr": "brigade_all_workers_by_phase{workerPhase=\"PENDING\"}",
+          "legendFormat": "Workers",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "brigade_pending_jobs_total",
+          "legendFormat": "Jobs",
+          "refId": "B"
         }
-      ],
-      "timeFrom": null,
-      "title": "Running Worker Duration History",
-      "type": "timeseries"
+      ]
     },
     {
-      "datasource": null,
+      "id": 30,
+      "title": "Service Accounts",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 6,
+        "h": 6
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -354,25 +278,13 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
+                "color": "light-blue"
               }
             ]
           }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 21,
-        "y": 14
-      },
-      "id": 30,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -382,7 +294,6 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
           "values": false
         },
         "text": {},
@@ -393,449 +304,9 @@
         {
           "exemplar": true,
           "expr": "brigade_service_accounts_total",
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
-      ],
-      "title": "Total Service Accounts",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 0,
-        "y": 21
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.2",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_running_jobs_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Current Running Jobs",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 6,
-        "y": 21
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_running_jobs_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Running Job History",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 0,
-        "y": 30
-      },
-      "id": 26,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.2",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_pending_jobs_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Current Pending Jobs",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 6,
-        "y": 30
-      },
-      "id": 28,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_pending_jobs_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Pending Job History",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 0,
-        "y": 39
-      },
-      "id": 24,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.2",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_all_workers_by_phase{workerPhase=\"PENDING\"}",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Current Pending Workers",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 6,
-        "y": 39
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "brigade_all_workers_by_phase{workerPhase=\"PENDING\"}",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Pending Workers History",
-      "type": "timeseries"
+      ]
     }
-  ],
-  "refresh": "5s",
-  "schemaVersion": 30,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-30m",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "Brigade",
-  "uid": "xDvsAAR7k",
-  "version": 4
+  ]
 }


### PR DESCRIPTION
This is some dashboard cleanup I did this morning.

* Removed panels that weren't providing useful info. Durations, for instance, don't tell us anything. Some workers and jobs might run quickly, different ones might run longer. Knowing the average duration for unlike things doesn't tell me anything useful.
* Consolidated panels for pending workers and pending jobs. i.e. They're now one graph with _two_ trend lines.
* Moved panels around and resized for aesthetic reasons.
* In the JSON:
    * Moved critical / most useful information up toward the top of each object/section. IDs, titles, etc. moved higher for improved human readability.
    * Added legend information wherever it helped
    * Removed anything that was redundant or unnecessary

Since this PR moves around a lot of JSON, it might be more useful to look at the finished product than to look at the diffs.

Also, here's a screenshot of what this looks like, with data from the dogfood cluster.

If lines are flat, it's because there's been no recent activity.

![Screen Shot 2021-07-20 at 11 23 38 AM](https://user-images.githubusercontent.com/1821014/126351034-953b5ebc-a89f-49ab-aa3c-a12b829f3487.png)

This PR doesn't touch the exporter, which is now exporting some things we no longer use. I will clean that up in a follow-up PR.

